### PR TITLE
Apply code standards

### DIFF
--- a/CultureObjectDisplay.php
+++ b/CultureObjectDisplay.php
@@ -67,10 +67,11 @@ function mds_cos_fields() {
 
 	$f = fopen( plugin_dir_path( __FILE__ ) . 'spectrum-display.csv', 'r' );
 
-	$i              = 0;
-	$displaySection = false;
+	$i               = 0;
+	$display_section = false;
 
-	while ( ( $line = fgetcsv( $f ) ) !== false ) {
+	$line = fgetcsv( $f );
+	while ( false !== $line ) {
 		if ( $i == 0 ) {
 			$html .= '<tr>';
 			foreach ( $line as $cell ) {
@@ -80,22 +81,22 @@ function mds_cos_fields() {
 			}
 			$html .= "</tr>\n";
 		} else {
-			$c      = 0;
-			$row    = '';
-			$newRow = false;
+			$c       = 0;
+			$row     = '';
+			$new_row = false;
 
 			foreach ( $line as $cell ) {
 				if ( $c == 0 && $cell !== '' ) {
-					if ( $displaySection ) {
-						$html          .= $section;
-						$displaySection = false;
+					if ( $display_section ) {
+						$html           .= $section;
+						$display_section = false;
 					}
 
 					$section = "<tr><td colspan='3'><strong>" . htmlspecialchars( $cell ) . '</strong></td></tr>';
-					$newRow  = true;
-				} elseif ( $newRow ) {
+					$new_row = true;
+				} elseif ( $new_row ) {
 						$section .= "<tr><td class='no-border'></td><td>" . htmlspecialchars( $cell );
-						$newRow   = false;
+						$new_row  = false;
 				} elseif ( $c == 3 ) {
 						$field_key = $cell;
 						$section  .= '<td>';
@@ -107,7 +108,7 @@ function mds_cos_fields() {
 						} else {
 							$section .= make_links_clickable( $fields[ $field_key ] );
 						}
-						$displaySection = true;
+						$display_section = true;
 					}
 						$section .= '</td></tr>';
 				} else {
@@ -126,6 +127,7 @@ function mds_cos_fields() {
 			}
 		}
 		++$i;
+		$line = fgetcsv( $f );
 	}
 
 	fclose( $f );


### PR DESCRIPTION
This pull request refactors the `CultureObjectDisplay.php` file to improve code readability and consistency by standardizing variable naming conventions and optimizing the CSV reading loop. The changes focus on making variable names more consistent with PHP best practices and ensuring the CSV file is read correctly.

**Code style and readability improvements:**

* Renamed variables from camelCase (`$displaySection`, `$newRow`) to snake_case (`$display_section`, `$new_row`) throughout the function for consistency with PHP naming conventions. [[1]](diffhunk://#diff-d5970d2d3a3a21897321a0f5179a4ba10e199c2f98d9cc08abb41114a2e0de5dL71-R74) [[2]](diffhunk://#diff-d5970d2d3a3a21897321a0f5179a4ba10e199c2f98d9cc08abb41114a2e0de5dL85-R99) [[3]](diffhunk://#diff-d5970d2d3a3a21897321a0f5179a4ba10e199c2f98d9cc08abb41114a2e0de5dL110-R111)

**Code correctness and maintainability:**

* Refactored the CSV reading loop to explicitly fetch the first line before the loop and update the line variable at the end of each iteration, improving clarity and preventing potential off-by-one errors. [[1]](diffhunk://#diff-d5970d2d3a3a21897321a0f5179a4ba10e199c2f98d9cc08abb41114a2e0de5dL71-R74) [[2]](diffhunk://#diff-d5970d2d3a3a21897321a0f5179a4ba10e199c2f98d9cc08abb41114a2e0de5dR130)